### PR TITLE
Fix Windows build process

### DIFF
--- a/.github/workflows/windows_linux.yml
+++ b/.github/workflows/windows_linux.yml
@@ -67,6 +67,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./scripts/hetuwScripts/windows/bin/OneLifeApp_H_windows.exe
+          asset_path: ./scripts/hetuwScripts/bin/OneLifeApp_H_windows.exe
           asset_name: OneLifeApp_H_windows.exe
           asset_content_type: application/zip

--- a/build/source/runToBuild
+++ b/build/source/runToBuild
@@ -47,7 +47,12 @@ ls
 
 
 echo "Copying items from build into directories"
-cp OneLife/gameSource/OneLife ./OneLifeApp
+if [ "$1" = "5" ] # windows
+then
+    cp OneLife/gameSource/OneLife.exe ./OneLifeApp.exe
+else
+    cp OneLife/gameSource/OneLife ./OneLifeApp
+fi
 cp OneLife/documentation/Readme.txt .
 cp OneLife/no_copyright.txt .
 cp OneLife/gameSource/graphics/* ./graphics

--- a/scripts/hetuwScripts/hetuwPullLatest.sh
+++ b/scripts/hetuwScripts/hetuwPullLatest.sh
@@ -79,12 +79,12 @@ fi
 
 if [ ! -e minorGems ]
 then
-	git clone https://github.com/selb/YumLifeMinorGems minorGems
+	git clone https://github.com/hetuw/minorGems
 fi
 
 if [ ! -e OneLife ]
 then
-	git clone https://github.com/selb/YumLife OneLife
+	git clone https://github.com/hetuw/OneLife
 fi
 
 


### PR DESCRIPTION
Looks like g++ was just adding an .exe to the end of the Windows binary, so it was getting lost. This should fix it.