### PR TITLE
Bugfix: Phex "Maximize" button was clickable when not drawn.

### DIFF
--- a/gameSource/phex.cpp
+++ b/gameSource/phex.cpp
@@ -998,6 +998,8 @@ void Phex::drawMinimized() {
 		mainChatWindow.drawMaxElements = 0;
 	}
 
+	butMaximize.visible = false;
+
 	double chatTop = mainChatWindow.getTopMinimum();
 	if (chatTop <= 0 && !bDrawRecInput) {
 		butPhex.visible = true;
@@ -1012,7 +1014,6 @@ void Phex::drawMinimized() {
 		recBckgr[3] = chatTop + textInRecPaddingY;
 	}
 
-	butMaximize.visible = false;
 	if (hasFocus) {
 		butMaximize.visible = true;
 		butMaximize.setY(recBckgr[3]);


### PR DESCRIPTION
This PR fixes a bug that caused the Phex "Maximize" button to be clickable in a case where it was not actually drawn.

Steps to reproduce:

- Press `#` to open Phex
- Hover over maximize button (or remember where it is and move mouse away, focus isn't relevant)
- Press `#` to close Phex
- Click where the maximize button was
